### PR TITLE
Gen example in help

### DIFF
--- a/src/plugins/azgenerator/CodeModelAz.ts
+++ b/src/plugins/azgenerator/CodeModelAz.ts
@@ -5,6 +5,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+export class CommandExample
+{
+    // this should be "create", "update", "list", "show", or custom name
+    public Method: string;
+    public Id: string;
+    public Title: string;
+    public Parameters: Map<string, string>;
+    // public MethodName: string;
+}
+
 export interface CodeModelAz
 {
     init(): any;
@@ -89,4 +99,5 @@ export interface CodeModelAz
     Example_Body: string[];
     Example_Title: string;
     Example_Params: any;
+    GetExamples(): CommandExample[];
 }

--- a/src/plugins/azgenerator/CodeModelAz.ts
+++ b/src/plugins/azgenerator/CodeModelAz.ts
@@ -13,6 +13,7 @@ export class CommandExample
     public Title: string;
     public Parameters: Map<string, string>;
     // public MethodName: string;
+    public Path: string;
 }
 
 export interface CodeModelAz
@@ -95,7 +96,7 @@ export interface CodeModelAz
 
     SelectFirstExample(): boolean;
     SelectNextExample(): boolean;
-    FindExampleById(id: string): string[];
+    FindExampleById(id: string): string[][];
     Example_Body: string[];
     Example_Title: string;
     Example_Params: any;

--- a/src/plugins/azgenerator/CodeModelAzImpl.ts
+++ b/src/plugins/azgenerator/CodeModelAzImpl.ts
@@ -3,23 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CodeModelAz } from "./CodeModelAz";
+import { CodeModelAz, CommandExample } from "./CodeModelAz";
 import { CodeModel, SchemaType, Schema, ParameterLocation, Operation, Value } from '@azure-tools/codemodel';
 import { serialize, deserialize } from "@azure-tools/codegen";
 import { Session, startSession, Host, Channel } from "@azure-tools/autorest-extension-base";
 import { ToSnakeCase } from '../../utils/helper';
 import { values } from "@azure-tools/linq";
 
-
-export class CommandExample
-{
-    // this should be "create", "update", "list", "show", or custom name
-    public Method: string;
-    public Id: string;
-    // public Title: string;
-    public Parameters: Map<string, string>;
-    // public MethodName: string;
-}
 
 export class CodeModelCliImpl implements CodeModelAz
 {
@@ -731,7 +721,7 @@ export class CodeModelCliImpl implements CodeModelAz
         return this.codeModel.operationGroups[this.currentOperationGroupIndex].operations[this.currentOperationIndex].extensions['x-ms-examples'][this.currentExampleIndex].value().parameters;
     }
 
-    public get Examples(): any {
+    public get Examples(): object {
         return this.codeModel.operationGroups[this.currentOperationGroupIndex].operations[this.currentMethodIndex].extensions['x-ms-examples'];
     }
 
@@ -814,13 +804,14 @@ export class CodeModelCliImpl implements CodeModelAz
     }
 
 
-    private GetExamples(): CommandExample[] {
+    public GetExamples(): CommandExample[] {
         let examples: CommandExample[] = [];
         if (this.Examples) {
             Object.entries(this.Examples).forEach(([id, example_obj]) => {
                 let example = new CommandExample();
                 example.Method = this.Command_MethodName;
                 example.Id = id;
+                example.Title = example_obj.title || id;
                 let params: Map<string, string> = this.GetExampleParameters(example_obj);
                 example.Parameters = this.ConvertToCliParameters(params);
                 examples.push(example);

--- a/src/plugins/azgenerator/CodeModelAzImpl.ts
+++ b/src/plugins/azgenerator/CodeModelAzImpl.ts
@@ -788,15 +788,14 @@ export class CodeModelCliImpl implements CodeModelAz
         let ret: Map<string, string> = new Map<string, string>();
         Object.entries(example_params).forEach(([param_name, param_value]) => {
             param_name = ToSnakeCase(param_name);
-            //// Here are some rename logic in POC, but not implement in current az codegen, so comment them here 
-            // if (param_name.endsWith('_name')) {
-            //     if (param_name == "resource_group_name") {
-            //         param_name = "resource_group";
-            //     }
-            //     else {
-            //         param_name = "name";
-            //     }
-            // }
+            if (param_name.endsWith('_name')) {
+                if (param_name == "resource_group_name") {
+                    param_name = "resource_group";
+                }
+                // else {
+                //     param_name = "name";
+                // }
+            }
             param_name = param_name.split("_").join("-");
             ret["--" + param_name] = param_value;
         });
@@ -828,7 +827,7 @@ export class CodeModelCliImpl implements CodeModelAz
         for (let k in example.Parameters) {
             let slp = JSON.stringify(example.Parameters[k]).split(/[\r\n]+/).join("");
             if (isTest) {
-                if (k != "--resource-group-name") {
+                if (k != "--resource-group") {
                     parameters.push(k + " " + slp);
                 }
                 else {

--- a/src/plugins/azgenerator/CodeModelAzImpl.ts
+++ b/src/plugins/azgenerator/CodeModelAzImpl.ts
@@ -755,7 +755,7 @@ export class CodeModelCliImpl implements CodeModelAz
                 this.AddFlattenedParameter(dict, k, k.language.default.name)
             }
         }
-        else {
+        else if (value?.schema?.type != 'constant') {
             dict[name] = value;
         }
     }

--- a/src/plugins/azgenerator/TemplateAzureCliHelp.ts
+++ b/src/plugins/azgenerator/TemplateAzureCliHelp.ts
@@ -81,28 +81,26 @@ function generateCommandHelp(model: CodeModelAz, needUpdate: boolean = false) {
 
     let examplesStarted: boolean = false;
 
-    if (model.SelectFirstExample()) {
-
-        do {
+    for( let example of model.GetExamples() ) {
             if (!examplesStarted) {
                 output.push("    examples:");
                 examplesStarted = true;
             }
 
-            //output.push ("# " + example.Method);
+            //output.push ("# " + example_id);
             let parameters: string[] = [];
 
             parameters.push("az");
             parameters = parameters.concat(model.Command_Name.split(" "));
             //parameters.push(method);
 
-            for (let k in model.Example_Params) {
-                let slp = JSON.stringify(model.Example_Params[k]).split(/[\r\n]+/).join("");
+            for (let k in example.Parameters) {
+                let slp = JSON.stringify(example.Parameters[k]).split(/[\r\n]+/).join("");
                 //parameters += " " + k + " " + slp;
                 parameters.push(k);
                 parameters.push(slp);
             }
-            output.push("      - name: " + model.Example_Title);
+            output.push("      - name: " + example.Title);
             output.push("        text: |-");
             let line = "";
             parameters.forEach(element => {
@@ -141,8 +139,6 @@ function generateCommandHelp(model: CodeModelAz, needUpdate: boolean = false) {
                 line = line.split("\\").join("\\\\");
                 output.push("               " + line);
             }
-        }
-        while (model.SelectNextExample());
     }
 
     output.push("\"\"\"");

--- a/src/plugins/azgenerator/TemplateAzureCliTestScenario.ts
+++ b/src/plugins/azgenerator/TemplateAzureCliTestScenario.ts
@@ -5,7 +5,7 @@
 
 import { CodeModelAz } from "./CodeModelAz"
 
-export function GenerateAzureCliTestScenario(model: CodeModelAz) : string[] {
+export function GenerateAzureCliTestScenario(model: CodeModelAz): string[] {
     let output: string[] = [];
     let config: any = model.Extension_TestScenario;
 
@@ -35,35 +35,33 @@ export function GenerateAzureCliTestScenario(model: CodeModelAz) : string[] {
     output.push("");
 
     // walk through test config
-    if (config)
-    {
-        for (var ci = 0; ci < config.length; ci++)
-        {
+    if (config) {
+        for (var ci = 0; ci < config.length; ci++) {
             let exampleId: string = config[ci].name;
             let disabled: string = config[ci].disabled ? "# " : "";
             // find example by name
 
-            let exampleCmd: string[] = model.FindExampleById(config[ci].name);
-            if (exampleCmd && exampleCmd.length > 0)
-            {
-                for (let idx = 0; idx < exampleCmd.length; idx++)
-                {
-                    let prefix: string = "        " + disabled + ((idx == 0) ? "self.cmd('" : "         '");
-                    let postfix: string = (idx < exampleCmd.length - 1) ? " '" : "',"; 
+            let found = false;
+            for (let exampleCmd of model.FindExampleById(config[ci].name)) {
+                if (exampleCmd && exampleCmd.length > 0) {
+                    found = true;
+                    for (let idx = 0; idx < exampleCmd.length; idx++) {
+                        let prefix: string = "        " + disabled + ((idx == 0) ? "self.cmd('" : "         '");
+                        let postfix: string = (idx < exampleCmd.length - 1) ? " '" : "',";
 
-                    output.push(prefix + exampleCmd[idx] + postfix);
+                        output.push(prefix + exampleCmd[idx] + postfix);
+                    }
+                    output.push("        " + disabled + "         checks=[])");
+                    output.push("");
                 }
-                output.push("        " + disabled + "         checks=[])");
-                output.push("");
             }
-            else
-            {
+            if (!found) {
                 output.push("        # EXAMPLE NOT FOUND: " + config[ci].name);
                 output.push("");
             }
         }
     }
-    
+
     return output;
 }
 

--- a/src/plugins/azgenerator/scenario_tool.ts
+++ b/src/plugins/azgenerator/scenario_tool.ts
@@ -1,0 +1,39 @@
+
+
+import { CommandExample } from "./CodeModelAz";
+
+function MethodToOrder(method: string): number {
+    if (method == 'create') return 0;
+    else if (method in ['show', 'list']) return 1;
+    else if (method == 'delete') return 3;
+    else return 2;
+}
+
+export function GenerateDefaultTestScenario(
+    examples: CommandExample[]): any[] {
+    console.warn("");
+    console.warn("NO TEST SCENARIO PROVIDED - DEFAULT WILL BE USED");
+    console.warn("ADD FOLLOWING SECTION TO readme.cli.md FILE TO MODIFY IT");
+    console.warn("--------------------------------------------------------");
+    console.warn("  test-scenario:");
+
+    let testScenario = [];
+
+    let sorted: CommandExample[] = examples.sort((e1, e2) => {
+        let n1 = MethodToOrder(e1.Method);
+        let n2 = MethodToOrder(e2.Method);
+        if (n1 == n2) {
+            if (e1.Method == "create") return (e1.Path.length > e2.Path.length) ? 1 : -1;
+            else return (e1.Path.length > e2.Path.length) ? -1 : 1;
+        }
+        return (n1 > n2) ? 1 : -1;
+    })
+
+    for (var i = 0; i < sorted.length; i++) {
+        var example: CommandExample = examples[i];
+        console.warn("    - name: " + example.Id);
+        testScenario.push({ name: example.Id })
+    }
+    console.warn("--------------------------------------------------------");
+    return testScenario;
+}

--- a/src/test/scenarios/managed-network/output/src/managed-network/azext_managed_network/_help.py
+++ b/src/test/scenarios/managed-network/output/src/managed-network/azext_managed_network/_help.py
@@ -16,11 +16,11 @@ helps['managed-network managed-networks'] = """
 
 helps['managed-network managed-networks list'] = """
     type: command
-    short-summary: The ListByResourceGroup ManagedNetwork operation retrieves all the Managed Network resources in a resource group in a paginated format.
+    short-summary: The ListBySubscription  ManagedNetwork operation retrieves all the Managed Network Resources in the current subscription in a paginated format.
     examples:
       - name: Get Managed Network
         text: |-
-               az managed-network managed_networks list --resource-group "myResourceGroup"
+               az managed-network managed-networks list --resource-group "myResourceGroup"
 """
 
 helps['managed-network managed-networks show'] = """
@@ -29,7 +29,8 @@ helps['managed-network managed-networks show'] = """
     examples:
       - name: Get Managed Network
         text: |-
-               az managed-network managed_networks show
+               az managed-network managed-networks show --managed-network-name "myManagedNetwork" \\
+               --resource-group "myResourceGroup"
 """
 
 helps['managed-network managed-networks create'] = """
@@ -38,7 +39,7 @@ helps['managed-network managed-networks create'] = """
     examples:
       - name: Create/Update Managed Network
         text: |-
-               az managed-network managed_networks create --location "eastus" --managed-network-name \\
+               az managed-network managed-networks create --location "eastus" --managed-network-name \\
                "myManagedNetwork" --resource-group "myResourceGroup"
 """
 
@@ -48,7 +49,7 @@ helps['managed-network managed-networks update'] = """
     examples:
       - name: Create/Update Managed Network
         text: |-
-               az managed-network managed_networks update --managed-network-name "myManagedNetwork" \\
+               az managed-network managed-networks update --managed-network-name "myManagedNetwork" \\
                --resource-group "myResourceGroup"
 """
 
@@ -58,7 +59,7 @@ helps['managed-network managed-networks delete'] = """
     examples:
       - name: Delete Managed Network
         text: |-
-               az managed-network managed_networks delete --managed-network-name "myManagedNetwork" \\
+               az managed-network managed-networks delete --managed-network-name "myManagedNetwork" \\
                --resource-group "myResourceGroup"
 """
 
@@ -73,7 +74,7 @@ helps['managed-network scope-assignments list'] = """
     examples:
       - name: Create/Update Managed Network
         text: |-
-               az managed-network scope_assignments list --scope "subscriptions/subscriptionC"
+               az managed-network scope-assignments list --scope "subscriptions/subscriptionC"
 """
 
 helps['managed-network scope-assignments show'] = """
@@ -82,7 +83,7 @@ helps['managed-network scope-assignments show'] = """
     examples:
       - name: Create/Update Managed Network
         text: |-
-               az managed-network scope_assignments show --scope "subscriptions/subscriptionC" \\
+               az managed-network scope-assignments show --scope "subscriptions/subscriptionC" \\
                --scope-assignment-name "subscriptionCAssignment"
 """
 
@@ -92,7 +93,7 @@ helps['managed-network scope-assignments create'] = """
     examples:
       - name: Create/Update Managed Network
         text: |-
-               az managed-network scope_assignments create --assigned-managed-network "/subscriptions/sub
+               az managed-network scope-assignments create --assigned-managed-network "/subscriptions/sub
                scriptionA/resourceGroups/myResourceGroup/providers/Microsoft.ManagedNetwork/managedNetwor
                ks/myManagedNetwork" --scope "subscriptions/subscriptionC" --scope-assignment-name \\
                "subscriptionCAssignment"
@@ -104,7 +105,7 @@ helps['managed-network scope-assignments update'] = """
     examples:
       - name: Create/Update Managed Network
         text: |-
-               az managed-network scope_assignments create --assigned-managed-network "/subscriptions/sub
+               az managed-network scope-assignments create --assigned-managed-network "/subscriptions/sub
                scriptionA/resourceGroups/myResourceGroup/providers/Microsoft.ManagedNetwork/managedNetwor
                ks/myManagedNetwork" --scope "subscriptions/subscriptionC" --scope-assignment-name \\
                "subscriptionCAssignment"
@@ -116,7 +117,7 @@ helps['managed-network scope-assignments delete'] = """
     examples:
       - name: Create/Update Managed Network
         text: |-
-               az managed-network scope_assignments delete --scope "subscriptions/subscriptionC" \\
+               az managed-network scope-assignments delete --scope "subscriptions/subscriptionC" \\
                --scope-assignment-name "subscriptionCAssignment"
 """
 
@@ -131,7 +132,7 @@ helps['managed-network managed-network-groups list'] = """
     examples:
       - name: Get Managed Network Group
         text: |-
-               az managed-network managed_network_groups list --managed-network-name "myManagedNetwork" \\
+               az managed-network managed-network-groups list --managed-network-name "myManagedNetwork" \\
                --resource-group "myResourceGroup"
 """
 
@@ -141,7 +142,7 @@ helps['managed-network managed-network-groups show'] = """
     examples:
       - name: Get Managed Network Group
         text: |-
-               az managed-network managed_network_groups show --managed-network-group-name \\
+               az managed-network managed-network-groups show --managed-network-group-name \\
                "myManagedNetworkGroup1" --managed-network-name "myManagedNetwork" --resource-group \\
                "myResourceGroup"
 """
@@ -152,7 +153,7 @@ helps['managed-network managed-network-groups create'] = """
     examples:
       - name: Create/Update Managed Network Group
         text: |-
-               az managed-network managed_network_groups create --managed-network-group-name \\
+               az managed-network managed-network-groups create --managed-network-group-name \\
                "myManagedNetworkGroup1" --managed-network-name "myManagedNetwork" --resource-group \\
                "myResourceGroup"
 """
@@ -163,7 +164,7 @@ helps['managed-network managed-network-groups update'] = """
     examples:
       - name: Create/Update Managed Network Group
         text: |-
-               az managed-network managed_network_groups create --managed-network-group-name \\
+               az managed-network managed-network-groups create --managed-network-group-name \\
                "myManagedNetworkGroup1" --managed-network-name "myManagedNetwork" --resource-group \\
                "myResourceGroup"
 """
@@ -174,7 +175,7 @@ helps['managed-network managed-network-groups delete'] = """
     examples:
       - name: Delete Managed Network Group
         text: |-
-               az managed-network managed_network_groups delete --managed-network-group-name \\
+               az managed-network managed-network-groups delete --managed-network-group-name \\
                "myManagedNetworkGroup1" --managed-network-name "myManagedNetwork" --resource-group \\
                "myResourceGroup"
 """
@@ -190,7 +191,7 @@ helps['managed-network managed-network-peering-policies list'] = """
     examples:
       - name: Get Managed Network Group
         text: |-
-               az managed-network managed_network_peering_policies list --managed-network-name \\
+               az managed-network managed-network-peering-policies list --managed-network-name \\
                "myManagedNetwork" --resource-group "myResourceGroup"
 """
 
@@ -200,7 +201,7 @@ helps['managed-network managed-network-peering-policies show'] = """
     examples:
       - name: Get Managed Network Peering Policy
         text: |-
-               az managed-network managed_network_peering_policies show --managed-network-name \\
+               az managed-network managed-network-peering-policies show --managed-network-name \\
                "myManagedNetwork" --managed-network-peering-policy-name "myHubAndSpoke" --resource-group \\
                "myResourceGroup"
 """
@@ -211,7 +212,7 @@ helps['managed-network managed-network-peering-policies create'] = """
     examples:
       - name: Create/Update Managed Network Peering Policy
         text: |-
-               az managed-network managed_network_peering_policies create --managed-network-name \\
+               az managed-network managed-network-peering-policies create --managed-network-name \\
                "myManagedNetwork" --managed-network-peering-policy-name "myHubAndSpoke" --type \\
                "HubAndSpokeTopology" --id "/subscriptionB/resourceGroups/myResourceGroup/providers/Micros
                oft.Network/virtualNetworks/myHubVnet" --resource-group "myResourceGroup"
@@ -223,7 +224,7 @@ helps['managed-network managed-network-peering-policies update'] = """
     examples:
       - name: Create/Update Managed Network Peering Policy
         text: |-
-               az managed-network managed_network_peering_policies create --managed-network-name \\
+               az managed-network managed-network-peering-policies create --managed-network-name \\
                "myManagedNetwork" --managed-network-peering-policy-name "myHubAndSpoke" --type \\
                "HubAndSpokeTopology" --id "/subscriptionB/resourceGroups/myResourceGroup/providers/Micros
                oft.Network/virtualNetworks/myHubVnet" --resource-group "myResourceGroup"
@@ -235,7 +236,7 @@ helps['managed-network managed-network-peering-policies delete'] = """
     examples:
       - name: Get Managed Network Peering Policy
         text: |-
-               az managed-network managed_network_peering_policies delete --managed-network-name \\
+               az managed-network managed-network-peering-policies delete --managed-network-name \\
                "myManagedNetwork" --managed-network-peering-policy-name "myHubAndSpoke" --resource-group \\
                "myResourceGroup"
 """

--- a/src/test/scenarios/managed-network/output/src/managed-network/azext_managed_network/_help.py
+++ b/src/test/scenarios/managed-network/output/src/managed-network/azext_managed_network/_help.py
@@ -17,26 +17,49 @@ helps['managed-network managed_networks'] = """
 helps['managed-network managed_networks list'] = """
     type: command
     short-summary: The ListByResourceGroup ManagedNetwork operation retrieves all the Managed Network resources in a resource group in a paginated format.
+    examples:
+      - name: Get Managed Network
+        text: |-
+               az managed-network managed_networks list --resource-group "myResourceGroup"
 """
 
 helps['managed-network managed_networks show'] = """
     type: command
     short-summary: The Get ManagedNetworks operation gets a Managed Network Resource, specified by the resource group and Managed Network name
+    examples:
+      - name: Get Managed Network
+        text: |-
+               az managed-network managed_networks show
 """
 
 helps['managed-network managed_networks create'] = """
     type: command
     short-summary: The Put ManagedNetworks operation creates/updates a Managed Network Resource, specified by resource group and Managed Network name
+    examples:
+      - name: Create/Update Managed Network
+        text: |-
+               az managed-network managed_networks create --location "eastus" --managed-network-name \\
+               "myManagedNetwork" --resource-group "myResourceGroup"
 """
 
 helps['managed-network managed_networks update'] = """
     type: command
     short-summary: Updates the specified Managed Network resource tags.
+    examples:
+      - name: Create/Update Managed Network
+        text: |-
+               az managed-network managed_networks update --managed-network-name "myManagedNetwork" \\
+               --resource-group "myResourceGroup"
 """
 
 helps['managed-network managed_networks delete'] = """
     type: command
     short-summary: The Delete ManagedNetworks operation deletes a Managed Network Resource, specified by the  resource group and Managed Network name
+    examples:
+      - name: Delete Managed Network
+        text: |-
+               az managed-network managed_networks delete --managed-network-name "myManagedNetwork" \\
+               --resource-group "myResourceGroup"
 """
 
 helps['managed-network scope_assignments'] = """
@@ -47,26 +70,54 @@ helps['managed-network scope_assignments'] = """
 helps['managed-network scope_assignments list'] = """
     type: command
     short-summary: Get the specified scope assignment.
+    examples:
+      - name: Create/Update Managed Network
+        text: |-
+               az managed-network scope_assignments list --scope "subscriptions/subscriptionC"
 """
 
 helps['managed-network scope_assignments show'] = """
     type: command
     short-summary: Get the specified scope assignment.
+    examples:
+      - name: Create/Update Managed Network
+        text: |-
+               az managed-network scope_assignments show --scope "subscriptions/subscriptionC" \\
+               --scope-assignment-name "subscriptionCAssignment"
 """
 
 helps['managed-network scope_assignments create'] = """
     type: command
     short-summary: Creates a scope assignment.
+    examples:
+      - name: Create/Update Managed Network
+        text: |-
+               az managed-network scope_assignments create --assigned-managed-network "/subscriptions/sub
+               scriptionA/resourceGroups/myResourceGroup/providers/Microsoft.ManagedNetwork/managedNetwor
+               ks/myManagedNetwork" --scope "subscriptions/subscriptionC" --scope-assignment-name \\
+               "subscriptionCAssignment"
 """
 
 helps['managed-network scope_assignments update'] = """
     type: command
     short-summary: Creates a scope assignment.
+    examples:
+      - name: Create/Update Managed Network
+        text: |-
+               az managed-network scope_assignments create --assigned-managed-network "/subscriptions/sub
+               scriptionA/resourceGroups/myResourceGroup/providers/Microsoft.ManagedNetwork/managedNetwor
+               ks/myManagedNetwork" --scope "subscriptions/subscriptionC" --scope-assignment-name \\
+               "subscriptionCAssignment"
 """
 
 helps['managed-network scope_assignments delete'] = """
     type: command
     short-summary: Deletes a scope assignment.
+    examples:
+      - name: Create/Update Managed Network
+        text: |-
+               az managed-network scope_assignments delete --scope "subscriptions/subscriptionC" \\
+               --scope-assignment-name "subscriptionCAssignment"
 """
 
 helps['managed-network managed_network_groups'] = """
@@ -77,26 +128,55 @@ helps['managed-network managed_network_groups'] = """
 helps['managed-network managed_network_groups list'] = """
     type: command
     short-summary: The ListByManagedNetwork ManagedNetworkGroup operation retrieves all the Managed Network Groups in a specified Managed Networks in a paginated format.
+    examples:
+      - name: Get Managed Network Group
+        text: |-
+               az managed-network managed_network_groups list --managed-network-name "myManagedNetwork" \\
+               --resource-group "myResourceGroup"
 """
 
 helps['managed-network managed_network_groups show'] = """
     type: command
     short-summary: The Get ManagedNetworkGroups operation gets a Managed Network Group specified by the resource group, Managed Network name, and group name
+    examples:
+      - name: Get Managed Network Group
+        text: |-
+               az managed-network managed_network_groups show --managed-network-group-name \\
+               "myManagedNetworkGroup1" --managed-network-name "myManagedNetwork" --resource-group \\
+               "myResourceGroup"
 """
 
 helps['managed-network managed_network_groups create'] = """
     type: command
     short-summary: The Put ManagedNetworkGroups operation creates or updates a Managed Network Group resource
+    examples:
+      - name: Create/Update Managed Network Group
+        text: |-
+               az managed-network managed_network_groups create --managed-network-group-name \\
+               "myManagedNetworkGroup1" --managed-network-name "myManagedNetwork" --resource-group \\
+               "myResourceGroup"
 """
 
 helps['managed-network managed_network_groups update'] = """
     type: command
     short-summary: The Put ManagedNetworkGroups operation creates or updates a Managed Network Group resource
+    examples:
+      - name: Create/Update Managed Network Group
+        text: |-
+               az managed-network managed_network_groups create --managed-network-group-name \\
+               "myManagedNetworkGroup1" --managed-network-name "myManagedNetwork" --resource-group \\
+               "myResourceGroup"
 """
 
 helps['managed-network managed_network_groups delete'] = """
     type: command
     short-summary: The Delete ManagedNetworkGroups operation deletes a Managed Network Group specified by the resource group, Managed Network name, and group name
+    examples:
+      - name: Delete Managed Network Group
+        text: |-
+               az managed-network managed_network_groups delete --managed-network-group-name \\
+               "myManagedNetworkGroup1" --managed-network-name "myManagedNetwork" --resource-group \\
+               "myResourceGroup"
 """
 
 helps['managed-network managed_network_peering_policies'] = """
@@ -107,26 +187,57 @@ helps['managed-network managed_network_peering_policies'] = """
 helps['managed-network managed_network_peering_policies list'] = """
     type: command
     short-summary: The ListByManagedNetwork PeeringPolicies operation retrieves all the Managed Network Peering Policies in a specified Managed Network, in a paginated format.
+    examples:
+      - name: Get Managed Network Group
+        text: |-
+               az managed-network managed_network_peering_policies list --managed-network-name \\
+               "myManagedNetwork" --resource-group "myResourceGroup"
 """
 
 helps['managed-network managed_network_peering_policies show'] = """
     type: command
     short-summary: The Get ManagedNetworkPeeringPolicies operation gets a Managed Network Peering Policy resource, specified by the  resource group, Managed Network name, and peering policy name
+    examples:
+      - name: Get Managed Network Peering Policy
+        text: |-
+               az managed-network managed_network_peering_policies show --managed-network-name \\
+               "myManagedNetwork" --managed-network-peering-policy-name "myHubAndSpoke" --resource-group \\
+               "myResourceGroup"
 """
 
 helps['managed-network managed_network_peering_policies create'] = """
     type: command
     short-summary: The Put ManagedNetworkPeeringPolicies operation creates/updates a new Managed Network Peering Policy
+    examples:
+      - name: Create/Update Managed Network Peering Policy
+        text: |-
+               az managed-network managed_network_peering_policies create --managed-network-name \\
+               "myManagedNetwork" --managed-network-peering-policy-name "myHubAndSpoke" --type \\
+               "HubAndSpokeTopology" --id "/subscriptionB/resourceGroups/myResourceGroup/providers/Micros
+               oft.Network/virtualNetworks/myHubVnet" --resource-group "myResourceGroup"
 """
 
 helps['managed-network managed_network_peering_policies update'] = """
     type: command
     short-summary: The Put ManagedNetworkPeeringPolicies operation creates/updates a new Managed Network Peering Policy
+    examples:
+      - name: Create/Update Managed Network Peering Policy
+        text: |-
+               az managed-network managed_network_peering_policies create --managed-network-name \\
+               "myManagedNetwork" --managed-network-peering-policy-name "myHubAndSpoke" --type \\
+               "HubAndSpokeTopology" --id "/subscriptionB/resourceGroups/myResourceGroup/providers/Micros
+               oft.Network/virtualNetworks/myHubVnet" --resource-group "myResourceGroup"
 """
 
 helps['managed-network managed_network_peering_policies delete'] = """
     type: command
     short-summary: The Delete ManagedNetworkPeeringPolicies operation deletes a Managed Network Peering Policy, specified by the  resource group, Managed Network name, and peering policy name
+    examples:
+      - name: Get Managed Network Peering Policy
+        text: |-
+               az managed-network managed_network_peering_policies delete --managed-network-name \\
+               "myManagedNetwork" --managed-network-peering-policy-name "myHubAndSpoke" --resource-group \\
+               "myResourceGroup"
 """
 
 helps['managed-network operations'] = """

--- a/src/test/scenarios/managed-network/output/src/managed-network/azext_managed_network/tests/latest/test_managed-network_scenario.py
+++ b/src/test/scenarios/managed-network/output/src/managed-network/azext_managed_network/tests/latest/test_managed-network_scenario.py
@@ -21,13 +21,13 @@ class ManagedNetworkManagementClientScenarioTest(ScenarioTest):
         self.cmd('az managed-network managed-networks create '
                  '--location "eastus" '
                  '--managed-network-name "myManagedNetwork" '
-                 '--resource-group-name {rg}',
+                 '--resource-group {rg}',
                  checks=[])
 
         self.cmd('az managed-network managed-network-groups create '
                  '--managed-network-group-name "myManagedNetworkGroup1" '
                  '--managed-network-name "myManagedNetwork" '
-                 '--resource-group-name {rg}',
+                 '--resource-group {rg}',
                  checks=[])
 
         self.cmd('az managed-network scope-assignments create '
@@ -41,16 +41,16 @@ class ManagedNetworkManagementClientScenarioTest(ScenarioTest):
                  '--managed-network-peering-policy-name "myHubAndSpoke" '
                  '--type "HubAndSpokeTopology" '
                  '--id "/subscriptionB/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myHubVnet" '
-                 '--resource-group-name {rg}',
+                 '--resource-group {rg}',
                  checks=[])
 
         self.cmd('az managed-network managed-networks show '
                  '--managed-network-name "myManagedNetwork" '
-                 '--resource-group-name {rg}',
+                 '--resource-group {rg}',
                  checks=[])
 
         self.cmd('az managed-network managed-networks list '
-                 '--resource-group-name {rg}',
+                 '--resource-group {rg}',
                  checks=[])
 
         self.cmd('az managed-network managed-networks show',
@@ -68,29 +68,29 @@ class ManagedNetworkManagementClientScenarioTest(ScenarioTest):
         self.cmd('az managed-network managed-network-groups show '
                  '--managed-network-group-name "myManagedNetworkGroup1" '
                  '--managed-network-name "myManagedNetwork" '
-                 '--resource-group-name {rg}',
+                 '--resource-group {rg}',
                  checks=[])
 
         self.cmd('az managed-network managed-network-groups list '
                  '--managed-network-name "myManagedNetwork" '
-                 '--resource-group-name {rg}',
+                 '--resource-group {rg}',
                  checks=[])
 
         self.cmd('az managed-network managed-network-peering-policies show '
                  '--managed-network-name "myManagedNetwork" '
                  '--managed-network-peering-policy-name "myHubAndSpoke" '
-                 '--resource-group-name {rg}',
+                 '--resource-group {rg}',
                  checks=[])
 
         self.cmd('az managed-network managed-network-peering-policies list '
                  '--managed-network-name "myManagedNetwork" '
-                 '--resource-group-name {rg}',
+                 '--resource-group {rg}',
                  checks=[])
 
         self.cmd('az managed-network managed-network-peering-policies delete '
                  '--managed-network-name "myManagedNetwork" '
                  '--managed-network-peering-policy-name "myHubAndSpoke" '
-                 '--resource-group-name {rg}',
+                 '--resource-group {rg}',
                  checks=[])
 
         self.cmd('az managed-network scope-assignments delete '
@@ -101,10 +101,10 @@ class ManagedNetworkManagementClientScenarioTest(ScenarioTest):
         self.cmd('az managed-network managed-network-groups delete '
                  '--managed-network-group-name "myManagedNetworkGroup1" '
                  '--managed-network-name "myManagedNetwork" '
-                 '--resource-group-name {rg}',
+                 '--resource-group {rg}',
                  checks=[])
 
         self.cmd('az managed-network managed-networks delete '
                  '--managed-network-name "myManagedNetwork" '
-                 '--resource-group-name {rg}',
+                 '--resource-group {rg}',
                  checks=[])


### PR DESCRIPTION
solve several issues in this PR:
1. generate example in _help.py
2. if several examples have a duplicated name, generate all of them
3. rename resource-group-name to resource-group
4. don't generate constant parameter.
5. generate default scenario if not configured