### PR TITLE
Operation group splitting

### DIFF
--- a/src/plugins/modifiers.ts
+++ b/src/plugins/modifiers.ts
@@ -144,38 +144,39 @@ export class Modifiers {
 
                     if (groupSplitter) {
                         for (const operationGroup of values(this.codeModel.operationGroups)) {
-                        if (!isNullOrUndefined(operationGroup.language['az']['command']) && operationGroup.language['az']['command'].match(groupRegex)) {
+                            if (!isNullOrUndefined(operationGroup.language['az']['command']) && operationGroup.language['az']['command'].match(groupRegex)) {
 
-                            let name = ToCamelCase(groupSplitter['group'].split(' ').pop());
-                            // splitting operation
-                            let splittedOperationGroup = new OperationGroup(name, operationGroup);
-                            splittedOperationGroup['$key'] = name;
-                            //splittedOperationGroup.language['az'] = {};
-                            splittedOperationGroup.language['az'] = {}
-                            splittedOperationGroup.language['az']['name'] = operationGroup.language['az']['name'];
-                            splittedOperationGroup.language['az']['description'] = operationGroup.language['az']['description'];
-                            splittedOperationGroup.language['az']['command'] = groupSplitter['group'];
-                            // split operations
-                            splittedOperationGroup.operations = [];
+                                let name = ToCamelCase(groupSplitter['group'].split(' ').pop());
+                                // splitting operation
+                                let splittedOperationGroup = new OperationGroup(name, operationGroup);
+                                splittedOperationGroup['$key'] = name;
+                                //splittedOperationGroup.language['az'] = {};
+                                splittedOperationGroup.language['az'] = {}
+                                splittedOperationGroup.language['az']['name'] = operationGroup.language['az']['name'];
+                                splittedOperationGroup.language['az']['description'] = operationGroup.language['az']['description'];
+                                splittedOperationGroup.language['az']['command'] = groupSplitter['group'];
+                                // split operations
+                                splittedOperationGroup.operations = [];
 
-                            let oldGroupOperations: Operation[] = [];
-                            // do actual splitting
-                            for (const operation of values(operationGroup.operations)) {
-                                groupSplitter['commands'].forEach(op => {
-                                    const opRegex = getPatternToMatch(op);
-                                    if (operation.language['az']['command'].match(opRegex)) {
-                                        splittedOperationGroup.operations.push(operation);
-                                    } else {
-                                        oldGroupOperations.push(operation);
-                                    }
-                                });
-                            }
+                                let oldGroupOperations: Operation[] = [];
+                                // do actual splitting
+                                for (const operation of values(operationGroup.operations)) {
+                                    groupSplitter['commands'].forEach(op => {
+                                        const opRegex = getPatternToMatch(op);
+                                        if (operation.language['az']['command'].match(opRegex)) {
+                                            splittedOperationGroup.operations.push(operation);
+                                        } else {
+                                            oldGroupOperations.push(operation);
+                                        }
+                                    });
+                                }
 
-                            operationGroup.operations = oldGroupOperations;
-                            this.codeModel.operationGroups.push(splittedOperationGroup);
+                                operationGroup.operations = oldGroupOperations;
+                                this.codeModel.operationGroups.push(splittedOperationGroup);
 
-                            for (const operation of values(splittedOperationGroup.operations)) {
-                                operation.language['az']['command'] = splittedOperationGroup.language['az']['command'] + " " + operation.language['az']['name'];
+                                for (const operation of values(splittedOperationGroup.operations)) {
+                                    operation.language['az']['command'] = splittedOperationGroup.language['az']['command'] + " " + operation.language['az']['name'];
+                                }
                             }
                         }
                     }

--- a/src/plugins/modifiers.ts
+++ b/src/plugins/modifiers.ts
@@ -142,41 +142,40 @@ export class Modifiers {
                     const groupSplitter: any = directive.set !== undefined ? directive.set["split"] : undefined;
                     const groupDescriptionReplacer = directive.set !== undefined? directive.set["group-description"]: undefined;
 
-                    for (const operationGroup of values(this.codeModel.operationGroups)) {
+                    if (groupSplitter) {
+                        for (const operationGroup of values(this.codeModel.operationGroups)) {
                         if (!isNullOrUndefined(operationGroup.language['az']['command']) && operationGroup.language['az']['command'].match(groupRegex)) {
 
-                            if (groupSplitter) {
-                                let name = ToCamelCase(groupSplitter['group'].split(' ').pop());
-                                // splitting operation
-                                let splittedOperationGroup = new OperationGroup(name, operationGroup);
-                                splittedOperationGroup['$key'] = name;
-                                //splittedOperationGroup.language['az'] = {};
-                                splittedOperationGroup.language['az'] = {}
-                                splittedOperationGroup.language['az']['name'] = operationGroup.language['az']['name'];
-                                splittedOperationGroup.language['az']['description'] = operationGroup.language['az']['description'];
-                                splittedOperationGroup.language['az']['command'] = groupSplitter['group'];
-                                // split operations
-                                splittedOperationGroup.operations = [];
+                            let name = ToCamelCase(groupSplitter['group'].split(' ').pop());
+                            // splitting operation
+                            let splittedOperationGroup = new OperationGroup(name, operationGroup);
+                            splittedOperationGroup['$key'] = name;
+                            //splittedOperationGroup.language['az'] = {};
+                            splittedOperationGroup.language['az'] = {}
+                            splittedOperationGroup.language['az']['name'] = operationGroup.language['az']['name'];
+                            splittedOperationGroup.language['az']['description'] = operationGroup.language['az']['description'];
+                            splittedOperationGroup.language['az']['command'] = groupSplitter['group'];
+                            // split operations
+                            splittedOperationGroup.operations = [];
 
-                                let oldGroupOperations: Operation[] = [];
-                                // do actual splitting
-                                for (const operation of values(operationGroup.operations)) {
-                                    groupSplitter['commands'].forEach(op => {
-                                        const opRegex = getPatternToMatch(op);
-                                        if (operation.language['az']['command'].match(opRegex)) {
-                                            splittedOperationGroup.operations.push(operation);
-                                        } else {
-                                            oldGroupOperations.push(operation);
-                                        }
-                                    });
-                                }
+                            let oldGroupOperations: Operation[] = [];
+                            // do actual splitting
+                            for (const operation of values(operationGroup.operations)) {
+                                groupSplitter['commands'].forEach(op => {
+                                    const opRegex = getPatternToMatch(op);
+                                    if (operation.language['az']['command'].match(opRegex)) {
+                                        splittedOperationGroup.operations.push(operation);
+                                    } else {
+                                        oldGroupOperations.push(operation);
+                                    }
+                                });
+                            }
 
-                                operationGroup.operations = oldGroupOperations;
-                                this.codeModel.operationGroups.push(splittedOperationGroup);
+                            operationGroup.operations = oldGroupOperations;
+                            this.codeModel.operationGroups.push(splittedOperationGroup);
 
-                                for (const operation of values(splittedOperationGroup.operations)) {
-                                    operation.language['az']['command'] = splittedOperationGroup.language['az']['command'] + " " + operation.language['az']['name'];
-                                }
+                            for (const operation of values(splittedOperationGroup.operations)) {
+                                operation.language['az']['command'] = splittedOperationGroup.language['az']['command'] + " " + operation.language['az']['name'];
                             }
                         }
                     }

--- a/src/plugins/modifiers.ts
+++ b/src/plugins/modifiers.ts
@@ -181,7 +181,7 @@ export class Modifiers {
                             operationGroup.language['az']['command'] = groupReplacer? groupRegex? operationGroup.language['az']['command'].replace(groupRegex, groupReplacer): groupReplacer: operationGroup.language['az']['command'];
                             operationGroup.language['az']['description'] = groupDescriptionReplacer? groupDescriptionReplacer: operationGroup.language['az']['description'];
                         }
-                        
+
                         for (const operation of values(operationGroup.operations)) {
                             //operation
                             if (groupChanged) {
@@ -190,8 +190,8 @@ export class Modifiers {
                             if (operation.language['az']['command'] != undefined && operation.language["az"]["command"].match(commandRegex)) {
                                 operation.language["az"]["command"] = commandReplacer? commandRegex? operation.language["az"]["command"].replace(commandRegex, commandReplacer): commandReplacer: operation.language["az"]["command"];
                                 operation.language["az"]["description"] = commandDescriptionReplacer? commandDescriptionReplacer: operation.language["az"]["description"];
+                                groupChanged = true;
                             }
-
                             for (const parameter of values(operation.parameters)) {
                                 if (parameter.language['az']['name'] != undefined && parameter.language["az"]["name"].match(parameterRegex)) {
                                     parameter.language["az"]["name"] = parameterReplacer? parameterRegex? parameter.language["az"]["name"].replace(parameterRegex, parameterReplacer): parameterReplacer: parameter.language["az"]["name"];
@@ -199,7 +199,6 @@ export class Modifiers {
                                     parameter.language["az"]["description"] = paramDescriptionReplacer? paramDescriptionReplacer: parameter.language["az"]["description"];
                                 }
                             }
-
                             for(const request of values(operation.requests)) {
                                 for (const parameter of values(request.parameters)) {
                                     if (parameter.language['az']['name'] != undefined && parameter.language["az"]["name"].match(parameterRegex)) {

--- a/src/plugins/modifiers.ts
+++ b/src/plugins/modifiers.ts
@@ -187,8 +187,8 @@ export class Modifiers {
                         if (!isNullOrUndefined(operationGroup.language['az']['command']) && operationGroup.language['az']['command'].match(groupRegex)) {
                             operationGroup.language['az']['command'] = groupReplacer? groupRegex? operationGroup.language['az']['command'].replace(groupRegex, groupReplacer): groupReplacer: operationGroup.language['az']['command'];
                             operationGroup.language['az']['description'] = groupDescriptionReplacer? groupDescriptionReplacer: operationGroup.language['az']['description'];
+                            groupChanged = true;
                         }
-
                         for (const operation of values(operationGroup.operations)) {
                             //operation
                             if (groupChanged) {
@@ -197,8 +197,8 @@ export class Modifiers {
                             if (operation.language['az']['command'] != undefined && operation.language["az"]["command"].match(commandRegex)) {
                                 operation.language["az"]["command"] = commandReplacer? commandRegex? operation.language["az"]["command"].replace(commandRegex, commandReplacer): commandReplacer: operation.language["az"]["command"];
                                 operation.language["az"]["description"] = commandDescriptionReplacer? commandDescriptionReplacer: operation.language["az"]["description"];
-                                groupChanged = true;
                             }
+
                             for (const parameter of values(operation.parameters)) {
                                 if (parameter.language['az']['name'] != undefined && parameter.language["az"]["name"].match(parameterRegex)) {
                                     parameter.language["az"]["name"] = parameterReplacer? parameterRegex? parameter.language["az"]["name"].replace(parameterRegex, parameterReplacer): parameterReplacer: parameter.language["az"]["name"];
@@ -206,6 +206,7 @@ export class Modifiers {
                                     parameter.language["az"]["description"] = paramDescriptionReplacer? paramDescriptionReplacer: parameter.language["az"]["description"];
                                 }
                             }
+
                             for(const request of values(operation.requests)) {
                                 for (const parameter of values(request.parameters)) {
                                     if (parameter.language['az']['name'] != undefined && parameter.language["az"]["name"].match(parameterRegex)) {

--- a/src/plugins/modifiers.ts
+++ b/src/plugins/modifiers.ts
@@ -16,6 +16,7 @@ import {
 import { serialize, deserialize } from "@azure-tools/codegen";
 import { values, items, length, Dictionary } from "@azure-tools/linq";
 import { isNullOrUndefined } from "util";
+import { ToCamelCase } from "../utils/helper";
 
 let directives: Array<any> = [];
 
@@ -145,8 +146,10 @@ export class Modifiers {
                         if (!isNullOrUndefined(operationGroup.language['az']['command']) && operationGroup.language['az']['command'].match(groupRegex)) {
 
                             if (groupSplitter) {
+                                let name = ToCamelCase(groupSplitter['group'].split(' ').pop());
                                 // splitting operation
-                                let splittedOperationGroup = new OperationGroup("splitted-operation", operationGroup);
+                                let splittedOperationGroup = new OperationGroup(name, operationGroup);
+                                splittedOperationGroup['$key'] = name;
                                 //splittedOperationGroup.language['az'] = {};
                                 splittedOperationGroup.language['az'] = {}
                                 splittedOperationGroup.language['az']['name'] = operationGroup.language['az']['name'];

--- a/src/plugins/modifiers.ts
+++ b/src/plugins/modifiers.ts
@@ -170,6 +170,10 @@ export class Modifiers {
 
                                 operationGroup.operations = oldGroupOperations;
                                 this.codeModel.operationGroups.push(splittedOperationGroup);
+
+                                for (const operation of values(splittedOperationGroup.operations)) {
+                                    operation.language['az']['command'] = splittedOperationGroup.language['az']['command'] + " " + operation.language['az']['name'];
+                                }
                             }
                         }
                     }

--- a/src/plugins/modifiers.ts
+++ b/src/plugins/modifiers.ts
@@ -221,7 +221,6 @@ export class Modifiers {
                 }
             }
         }
-
         // add NameMapsTo after modifier and if generic update exists, set the setter_arg_name
         this.codeModel.operationGroups.forEach(operationGroup => {
             let operations = operationGroup.operations;

--- a/src/plugins/modifiers.ts
+++ b/src/plugins/modifiers.ts
@@ -140,42 +140,48 @@ export class Modifiers {
                     const groupReplacer = directive.set !== undefined ? directive.set["group"] : undefined;
                     const groupSplitter: any = directive.set !== undefined ? directive.set["split"] : undefined;
                     const groupDescriptionReplacer = directive.set !== undefined? directive.set["group-description"]: undefined;
-                    
+
+                    for (const operationGroup of values(this.codeModel.operationGroups)) {
+                        if (!isNullOrUndefined(operationGroup.language['az']['command']) && operationGroup.language['az']['command'].match(groupRegex)) {
+
+                            if (groupSplitter) {
+                                // splitting operation
+                                let splittedOperationGroup = new OperationGroup("splitted-operation", operationGroup);
+                                //splittedOperationGroup.language['az'] = {};
+                                splittedOperationGroup.language['az'] = {}
+                                splittedOperationGroup.language['az']['name'] = operationGroup.language['az']['name'];
+                                splittedOperationGroup.language['az']['description'] = operationGroup.language['az']['description'];
+                                splittedOperationGroup.language['az']['command'] = groupSplitter['group'];
+                                // split operations
+                                splittedOperationGroup.operations = [];
+
+                                let oldGroupOperations: Operation[] = [];
+                                // do actual splitting
+                                for (const operation of values(operationGroup.operations)) {
+                                    groupSplitter['commands'].forEach(op => {
+                                        const opRegex = getPatternToMatch(op);
+                                        if (operation.language['az']['command'].match(opRegex)) {
+                                            splittedOperationGroup.operations.push(operation);
+                                        } else {
+                                            oldGroupOperations.push(operation);
+                                        }
+                                    });
+                                }
+
+                                operationGroup.operations = oldGroupOperations;
+                                this.codeModel.operationGroups.push(splittedOperationGroup);
+                            }
+                        }
+                    }
+
                     for (const operationGroup of values(this.codeModel.operationGroups)) {
                         //operationGroup
                         let groupChanged = false;
                         if (!isNullOrUndefined(operationGroup.language['az']['command']) && operationGroup.language['az']['command'].match(groupRegex)) {
                             operationGroup.language['az']['command'] = groupReplacer? groupRegex? operationGroup.language['az']['command'].replace(groupRegex, groupReplacer): groupReplacer: operationGroup.language['az']['command'];
                             operationGroup.language['az']['description'] = groupDescriptionReplacer? groupDescriptionReplacer: operationGroup.language['az']['description'];
-
-                            // splitting operation
-                            let splittedOperationGroup = new OperationGroup("splitted-operation", operationGroup);
-                            //splittedOperationGroup.language['az'] = {};
-                            splittedOperationGroup.language['az'] = {}
-                            splittedOperationGroup.language['az']['name'] = operationGroup.language['az']['name'];
-                            splittedOperationGroup.language['az']['description'] = operationGroup.language['az']['description'];
-                            splittedOperationGroup.language['az']['command'] = operationGroup.language['az']['command'] = groupSplitter['command'];
-                            // split operations
-                            splittedOperationGroup.operations = [];
-
-                            let oldGroupOperations: Operation[] = [];
-                            // do actual splitting
-                            for (const operation of values(operationGroup.operations)) {
-                                groupSplitter['commands'].forEach(op => {
-                                    const opRegex = getPatternToMatch(op);
-                                    if (operation.language['az']['command'].match(opRegex)) {
-                                        splittedOperationGroup.operations.push(operation);
-                                    } else {
-                                        oldGroupOperations.push(operation);
-                                    }
-                                });
-                            }
-
-                            operationGroup.operations = oldGroupOperations;
-                            this.codeModel.operationGroups.push(splittedOperationGroup);
-
-                            groupChanged = true;
                         }
+                        
                         for (const operation of values(operationGroup.operations)) {
                             //operation
                             if (groupChanged) {
@@ -208,6 +214,7 @@ export class Modifiers {
                 }
             }
         }
+
         // add NameMapsTo after modifier and if generic update exists, set the setter_arg_name
         this.codeModel.operationGroups.forEach(operationGroup => {
             let operations = operationGroup.operations;


### PR DESCRIPTION
Groups can be split as follows:

where/group - operation group to split
set/group - newly created command group
set/commands - list of regexes to identify commands to move to the new group.

``` yaml $(az)
directive:
  - where:
      group: '^storageimportexport job$'
    set:
      split:
        group: 'storageimportexport jobxxx'
        commands:
          - 'storageimportexport job delete'
```