### PR TITLE
inplace doc, and update zipfile after codegen succeed

### DIFF
--- a/doc/05-Inplace-edit-guide.md
+++ b/doc/05-Inplace-edit-guide.md
@@ -1,0 +1,53 @@
+# Inplace-edit Guide
+The inplace-edit feature is supported in the generated test scenario files.
+
+## What's inplace-edit feature
+Traditionally, file contents in auto-gen files will be covered/lost every time run codegen.
+With inplace-edit feature, you can edit generated files at will. And the changed content can be *merged* to the next round time auto-gen files.
+So below circle is supported for codegen files:
+
+auto-generate file --> modify it --> auto-generate file --> modify it-->...
+
+With no fear to worry about modifed content loss in each auto-gen.
+
+
+## What's the restrictions
+This feature can be leveraged by following below rules:
+- don't change className/functionName/variableName in autogen file.
+- commit the manual modification before everytime run codegen. (to avoid unintend lose)
+- code review needed: conflict happens in rare case.
+
+
+## What's a conflict
+If both swagger and you make some change in one exactly same line of code, then there will be a conflict.
+
+When confilct happens, both swagger change and manual change will be shown in generated file.
+
+For instance:
+
+1) If the generated code is like this:
+~~~
+    test.cmd('az desktopvirtualization workspace update '
+             '--description "des2" '
+             checks=checks)
+~~~
+
+2) and then you edit it manually into:
+~~~
+    test.cmd('az desktopvirtualization workspace update '
+             '--description "des2_manual_change" '                  # this line is changed manually
+             checks=checks)
+~~~
+
+3) in the same time, the --description in swagger example file is changed to "des2_swagger_change" 
+
+
+4) So the conflicat happens, the generated code will be like below.
+~~~
+    test.cmd('az desktopvirtualization workspace update '
+             '--description "des2_manual_change" '                  # manuall change
+             '--description "des2_swagger_change" '                 # swagger change
+             checks=checks)
+~~~
+
+5) In this case, conflict need to be handled manually (just delete the line you don't like in-placely).

--- a/src/plugins/azgenerator/azgenerator.ts
+++ b/src/plugins/azgenerator/azgenerator.ts
@@ -7,6 +7,7 @@ import { ArgumentConstants, GenerationMode, PathConstants } from "../models";
 import { AzGeneratorFactory } from "./AzGeneratorFactory";
 import { CodeModelCliImpl } from "./CodeModelAzImpl";
 import { HeaderGenerator } from './Header';
+import { openInplaceGen, closeInplaceGen} from '../../utils/inplace'
 
 export async function processRequest(host: Host) {
     const debug = await host.GetValue('debug') || false;
@@ -41,6 +42,7 @@ export async function processRequest(host: Host) {
         model.CliGenerationMode = await autoDetectGenerationMode(host, model.AzextFolder, model.IsCliCore);
         model.CliOutputFolder = azOutputFolder;
 
+        openInplaceGen();
         let generator = await AzGeneratorFactory.createAzGenerator(model, debug);
         await generator.generateAll();
         let files = generator.files;
@@ -58,8 +60,8 @@ export async function processRequest(host: Host) {
             if (!isNullOrUndefined(files[f])) {
                 host.WriteFile(f, files[f].join(EOL));
             }
-            
         }
+        closeInplaceGen();
     } catch (E) {
         if (debug) {
             console.error(`${__filename} - FAILURE  ${JSON.stringify(E)} ${E.stack}`);

--- a/src/utils/inplace.ts
+++ b/src/utils/inplace.ts
@@ -500,12 +500,24 @@ export function loadFromZip(zipFile: string, genFile: string): string[] {
     return undefined;
 }
 
+let zipBuffer = [];
+
+export function openInplaceGen() {
+    zipBuffer = [];
+}
+
 export function inplaceGen(outputFolder: string, filename: string, genContent: string[]): string[] {
     let zipGenFile = join(outputFolder, "gen.zip");
     let originA = createTarget(loadFromZip(zipGenFile, filename));
     let customizedA = createTarget(join(outputFolder, filename));
-    zipFile(zipGenFile, filename, genContent);
+    zipBuffer.push([zipGenFile, filename, genContent]);
     let target = createTarget(genContent);
     target.merge(originA, customizedA);
     return target.getContent();
+}
+
+export function closeInplaceGen()  {
+    for (let meta of zipBuffer) {
+        zipFile(meta[0], meta[1], meta[2]);
+    }
 }


### PR DESCRIPTION
1. for #616 
2. update zip file after codegen succeed. (to avoid the failed codegen status to be zipped)