### PR TITLE
fix package issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
   "devDependencies": {
     "@microsoft.azure/autorest.testserver": "^2.10.45",
     "@types/chai": "^4.2.7",
-    "@types/mocha": "^5.2.5",
-    "@types/node": "10.17.0",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.0",
     "bufferutil": "^4.0.1",
@@ -77,7 +75,9 @@
     "nunjucks": "^3.2.2",
     "prettier": "^2.2.1",
     "request": "^2.87.0",
-    "request-promise-native": "1.0.8"
+    "request-promise-native": "1.0.8",
+    "@types/mocha": "^5.2.5",
+    "@types/node": "10.17.0"
   },
   "files": [
     "dist/src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/az",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Autorest Azure AZ extension",
   "main": "dist/src/index.js",
   "engines": {


### PR DESCRIPTION
This PR is trying to fix the npm pack issue. currently, the private released tgz file can not really work because it misses package dependencies `@types/node` for the postinstall script. which should have been in dependencies but now in devDependencies.